### PR TITLE
fix: guard agent calls until CSV is uploaded & add predetermined intro messages

### DIFF
--- a/dataverse_agent/messages.py
+++ b/dataverse_agent/messages.py
@@ -1,0 +1,22 @@
+"""
+Predetermined chat messages for the DataVerse Agent Dashboard.
+Centralizing messages here keeps the main dashboard file clean and makes
+it easy to add, edit, or translate messages in one place.
+"""
+
+INTRO_MESSAGES = [
+    "👋 Hey there! I'm your DataVerse Analyst. Upload a CSV file and let's uncover some insights together!",
+    "🚀 Welcome to DataVerse! Ready to turn your data into stunning visualizations? Start by uploading a CSV file.",
+    "📊 Hi! I'm here to help you explore and visualize your data. Drop a CSV file to get started!",
+    "🔍 Hello! Let's dive into your data. Upload a CSV file and I'll help you discover patterns and trends.",
+    "✨ Welcome! I'm your data exploration assistant. Share a CSV file and let's create some amazing dashboards!",
+    "💡 Hey! Ready to make sense of your data? Upload a CSV file and we'll get started right away.",
+    "🎯 Hi there! I specialize in turning raw data into actionable insights. Upload a CSV to begin!",
+]
+
+NO_CSV_MESSAGES = [
+    "📂 It looks like you haven't uploaded a dataset yet. Please attach a CSV file so I can start analyzing!",
+    "⚠️ I need data to work with! Please upload a CSV file along with your message.",
+    "🗂️ No dataset detected. Drop a CSV file in the chat and I'll get right on it!",
+    "📎 Before I can help, I'll need some data. Please upload a CSV file to continue.",
+]

--- a/streamlit_agent_dashboard.py
+++ b/streamlit_agent_dashboard.py
@@ -1,4 +1,5 @@
 import io
+import random
 import streamlit as st
 import pandas as pd
 from google import genai
@@ -6,6 +7,7 @@ from google.genai import types
 
 from models.utils import load_csv, extract_non_code_text, extract_python_code_blocks, execute_python_code
 from dataverse_agent.agent import root_agent
+from dataverse_agent.messages import INTRO_MESSAGES, NO_CSV_MESSAGES
 
 st.set_page_config(page_title="DataVerse - Dashboard Generation", layout="wide")
 
@@ -73,8 +75,7 @@ with chat_col:
         )
 
     if "messages" not in st.session_state: # type: ignore
-        resp = safe_chat_send(st.session_state.chat, "Please introduce yourself and offer to help analyze the data.")
-        initial_msg = resp.text if resp else "I am your DataVerse Analyst. Let's explore your data!"
+        initial_msg = random.choice(INTRO_MESSAGES)
         st.session_state.messages = [{"role": "assistant", "content": initial_msg}]
 
     # Render previous chat history
@@ -130,6 +131,12 @@ with chat_col:
 
         # The actual prompt we send to the LLM
         llm_prompt = user_text + append_data_context
+
+        # Guard: if no dataset is loaded yet, ask the user to upload a CSV first
+        if st.session_state.modified_df is None and not uploaded_files:
+            st.session_state.messages.append({"role": "user", "content": user_text}) # type: ignore
+            st.session_state.messages.append({"role": "assistant", "content": random.choice(NO_CSV_MESSAGES)}) # type: ignore
+            st.rerun()
 
         # Add only the user's text to the visible UI history
         st.session_state.messages.append({"role": "user", "content": user_text}) # type: ignore


### PR DESCRIPTION
## Summary

Closes #2

## Changes

### 🛡️ CSV Upload Guard
Before this fix, users could send messages to the agent without any dataset loaded, which resulted in unhelpful or confusing responses. Now, if no CSV has been uploaded yet, the app responds with a friendly random prompt asking the user to upload a file — **no agent call is made**.

### 🎲 Random Predetermined Intro Messages
The initial greeting no longer calls the LLM (which wasted an API call just to say hello). Instead, one of 7 pre-written intro messages is picked randomly on page load.

### 🗂️ Extracted Messages to Separate Module
All chat messages (`INTRO_MESSAGES`, `NO_CSV_MESSAGES`) have been moved to `dataverse_agent/messages.py` to keep `streamlit_agent_dashboard.py` clean and make messages easy to manage in one place.

## Files Changed
- `streamlit_agent_dashboard.py` — import messages, add guard logic
- `dataverse_agent/messages.py` *(new)* — centralized message store